### PR TITLE
Symbolic add

### DIFF
--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 import pytest
 from kriscv.symtools import SymTools

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import pytest
+from kriscv.tools import Tools
+
+from .utils import TemplateLoader
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def load_template(tmp_path: Path) -> TemplateLoader:
+    return TemplateLoader(tmp_path)
+
+
+@pytest.fixture
+def tools(tmp_path: Path) -> Callable[[str], Tools]:
+    def _tools(target: str) -> Tools:
+        from pyk.kdist import kdist
+
+        definition_dir = kdist.get(target)
+
+        temp_dir = tmp_path / 'kriscv'
+        temp_dir.mkdir()
+        return Tools(definition_dir, temp_dir=temp_dir)
+
+    return _tools

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable
 
 import pytest
+from kriscv.symtools import SymTools
 from kriscv.tools import Tools
 
 from .utils import TemplateLoader
@@ -28,3 +29,8 @@ def tools(tmp_path: Path) -> Callable[[str], Tools]:
         return Tools(definition_dir, temp_dir=temp_dir)
 
     return _tools
+
+
+@pytest.fixture
+def symtools(tmp_path: Path) -> SymTools:
+    return SymTools.default(proof_dir=tmp_path)

--- a/src/tests/integration/test_integration.py
+++ b/src/tests/integration/test_integration.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from pyk.utils import run_process_2
 
-from .utils import RISC0_CONFIG, SP1_CONFIG, get_symbols, resolve_symbol
+from .utils import RISC0_CONFIG, SP1_CONFIG, build_elf, get_symbols, resolve_symbol
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -34,23 +33,7 @@ def test_add(
     build_config: BuildConfig,
 ) -> None:
     # Given
-    project_name = 'add-test'
-    project_dir = load_template(
-        template_name=project_name,
-        context={
-            'zkvm_deps': build_config.zkvm_deps,
-            'src_header': build_config.src_header,
-        },
-    )
-
-    # When
-    run_process_2(build_config.build_cmd, cwd=project_dir)
-    elf_file = project_dir / build_config.elf_path / project_name
-
-    # Then
-    assert elf_file.is_file()
-
-    # And given
+    elf_file = build_elf('add-test', load_template, build_config)
     result_addr = resolve_symbol(elf_file, 'RESULT')
     (end_symbol,) = get_symbols(elf_file, build_config.end_pattern)
     kriscv = tools(build_config.target)

--- a/src/tests/integration/test_integration.py
+++ b/src/tests/integration/test_integration.py
@@ -1,122 +1,19 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING
 
 import pytest
-from kriscv.tools import Tools
 from pyk.utils import run_process_2
 
-from .utils import RISC0_VERSION, SP1_VERSION, TEST_DATA_DIR
+from .utils import RISC0_CONFIG, SP1_CONFIG, get_symbols, resolve_symbol
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
-    from pathlib import Path
+    from collections.abc import Callable
     from typing import Final
 
-    from elftools.elf.elffile import ELFFile  # type: ignore
+    from kriscv.tools import Tools
 
-
-TEMPLATE_DIR: Final = TEST_DATA_DIR / 'templates'
-
-
-class TemplateLoader:
-    _path: Path
-
-    def __init__(self, path: Path):
-        self._path = path
-
-    def __call__(
-        self,
-        *,
-        template_name: str,
-        context: dict[str, str],
-    ) -> Path:
-        from jinja2 import Environment, FileSystemLoader, StrictUndefined
-
-        src_dir = TEMPLATE_DIR / template_name
-        trg_dir = self._path / template_name
-
-        template_files = [path.relative_to(src_dir) for path in src_dir.rglob('*') if path.is_file()]
-        env = Environment(loader=FileSystemLoader(str(src_dir)), undefined=StrictUndefined)
-        for file in template_files:
-            template = env.get_template(str(file))
-            rendered = template.render(context)
-            out_file = trg_dir / file
-            out_file.parent.mkdir(parents=True, exist_ok=True)
-            out_file.write_text(rendered)
-
-        return trg_dir
-
-
-@pytest.fixture
-def load_template(tmp_path: Path) -> TemplateLoader:
-    return TemplateLoader(tmp_path)
-
-
-@pytest.fixture
-def tools(tmp_path: Path) -> Callable[[str], Tools]:
-    def _tools(target: str) -> Tools:
-        from pyk.kdist import kdist
-
-        definition_dir = kdist.get(target)
-
-        temp_dir = tmp_path / 'kriscv'
-        temp_dir.mkdir()
-        return Tools(definition_dir, temp_dir=temp_dir)
-
-    return _tools
-
-
-class BuildConfig(NamedTuple):
-    build_cmd: tuple[str, ...]
-    zkvm_deps: str
-    src_header: str
-    elf_path: str
-    end_pattern: str
-    target: str
-
-
-def dedent(text: str) -> str:
-    import textwrap
-
-    return textwrap.dedent(text).strip()
-
-
-RISC0_CONFIG: Final = BuildConfig(
-    build_cmd=('cargo', 'risczero', 'build'),
-    zkvm_deps=dedent(
-        f"""
-        bytemuck_derive = "=1.8.1"
-        risc0-zkvm = {{ version = "={RISC0_VERSION}", default-features = false }}
-        """
-    ),
-    src_header=dedent(
-        """
-        #![no_main]
-        #![no_std]
-        #![feature(unsafe_attributes)]
-        risc0_zkvm::guest::entry!(main);
-        """
-    ),
-    elf_path='target/riscv32im-risc0-zkvm-elf/docker',
-    end_pattern='sys_halt',
-    target='zkevm-semantics.risc0',
-)
-
-SP1_CONFIG: Final = BuildConfig(
-    build_cmd=('cargo', 'prove', 'build'),
-    zkvm_deps=f'sp1-zkvm = "={SP1_VERSION}"',
-    src_header=dedent(
-        """
-        #![no_main]
-        sp1_zkvm::entrypoint!(main);
-        """
-    ),
-    elf_path='target/elf-compilation/riscv32im-succinct-zkvm-elf/release',
-    end_pattern='_ZN8sp1_zkvm8syscalls4halt12syscall_halt*',
-    target='zkevm-semantics.sp1',
-)
+    from .utils import BuildConfig, TemplateLoader
 
 
 ADD_TEST_DATA: Final = (
@@ -167,35 +64,3 @@ def test_add(
 
     # Then
     assert kriscv.get_memory(config)[result_addr + 31] == 3
-
-
-def resolve_symbol(elf_file: Path, symbol: str) -> int:
-    from kriscv.elf_parser import read_unique_symbol
-
-    with _elf_file(file=elf_file) as elf:
-        return read_unique_symbol(elf, symbol, error_loc=None)
-
-
-def get_symbols(elf_file: Path, pattern: str) -> list[str]:
-    import fnmatch
-
-    with _elf_file(file=elf_file) as elf:
-        symtab = elf.get_section_by_name('.symtab')
-        assert symtab
-
-        func_symbols = [
-            sym.name
-            for sym in symtab.iter_symbols()
-            if sym['st_info']['type'] == 'STT_FUNC'  # Check if symbol type is FUNC
-        ]
-
-        return fnmatch.filter(func_symbols, pattern)
-
-
-@contextmanager
-def _elf_file(file: Path) -> Iterator[ELFFile]:
-    from elftools.elf.elffile import ELFFile  # type: ignore
-
-    with file.open('rb') as f:
-        elf = ELFFile(f)
-        yield elf

--- a/src/tests/integration/test_prove.py
+++ b/src/tests/integration/test_prove.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Final, cast
+
+import pytest
+from kriscv.elf_parser import _memory_segments, entry_point, read_unique_symbol
+from kriscv.term_builder import (
+    dot_sb,
+    halt_at_address,
+    normalize_memory,
+    regs,
+    sb_bytes,
+    sb_bytes_cons,
+    sb_empty,
+    sb_empty_cons,
+    word,
+)
+from pyk.cterm import CSubst, CTerm, cterm_build_claim
+from pyk.kast.inner import KApply, KInner, KSequence, KSort, KVariable, Subst
+from pyk.prelude.bytes import bytesToken
+from pyk.prelude.kint import eqInt, intToken
+from pyk.prelude.ml import mlEqualsTrue
+from pyk.proof.reachability import APRProof, APRProver
+from pyk.proof.show import APRProofShow
+
+from .utils import DEBUG_DIR, SP1_CONFIG, _elf_file, build_elf, get_symbols, resolve_symbol
+
+if TYPE_CHECKING:
+    from kriscv.symtools import SymTools
+    from kriscv.tools import Tools
+
+    from .utils import BuildConfig, TemplateLoader
+
+PROVE_TEST_DATA: Final = (('add-test', 2, SP1_CONFIG),)
+
+
+def length_bytes(var: str) -> KInner:
+    # TODO: Move to riscv semantics
+    return KApply('lengthBytes(_)_BYTES-HOOKED_Int_Bytes', [KVariable(var, 'Bytes')])
+
+
+def add_bytes(bytes1: KInner, bytes2: KInner) -> KInner:
+    # TODO: Move to riscv semantics
+    return KApply('_+Bytes__BYTES-HOOKED_Bytes_Bytes_Bytes', bytes1, bytes2)
+
+
+def sparse_symbolic_bytes(data: dict[int, bytes], symbolic_bytes: dict[int, tuple[int, str]]) -> KInner:
+    # TODO: Move to riscv semantics; extract reusable parts into functions
+    symbolic_bytes = dict(sorted(symbolic_bytes.items(), key=lambda item: item[0]))
+
+    clean_data: list[tuple[int, bytes]] = sorted(normalize_memory(data).items())
+
+    if len(clean_data) == 0:
+        return dot_sb()
+
+    # Collect all empty gaps between segements
+    gaps = []
+    start = clean_data[0][0]
+    if start != 0:
+        gaps.append((0, start))
+    for (start1, val1), (start2, _) in itertools.pairwise(clean_data):
+        end1 = start1 + len(val1)
+        # normalize_memory should already have merged consecutive segments
+        assert end1 < start2
+        gaps.append((end1, start2 - end1))
+
+    # Merge segments and gaps into a list of sparse bytes items
+    sparse_data: list[tuple[int, int | bytes]] = sorted(
+        cast('list[tuple[int, int | bytes]]', clean_data) + cast('list[tuple[int, int | bytes]]', gaps), reverse=True
+    )
+
+    sparse_k = dot_sb()
+    for addr, gap_or_val in sparse_data:
+        if isinstance(gap_or_val, int):
+            for symaddr, symsize, symname in symbolic_bytes.items():
+                if addr <= symaddr < addr + gap_or_val:
+                    assert symaddr + symsize <= addr + gap_or_val
+                    assert False, 'We do not support to make empty segments with partial symbolic bytes!'
+            sparse_k = sb_empty_cons(sb_empty(intToken(gap_or_val)), sparse_k)
+        elif isinstance(gap_or_val, bytes):
+            curr_addr = addr
+            curr_bytes = None
+            for symaddr, symsize, symname in symbolic_bytes.items():
+                if addr <= symaddr < addr + gap_or_val:
+                    assert symaddr + symsize <= addr + gap_or_val
+                    # Extract bytes before the variable
+                    if symaddr > curr_addr:
+                        temp_bytes = bytesToken(gap_or_val[curr_addr - addr : symaddr - addr])
+                        curr_bytes = add_bytes(curr_bytes, temp_bytes) if curr_bytes else temp_bytes
+                    # Add the variable
+                    curr_bytes = (
+                        add_bytes(curr_bytes, KVariable(symname, 'Bytes'))
+                        if curr_bytes
+                        else KVariable(symname, 'Bytes')
+                    )
+                    # Skip over the variable bytes
+                    curr_addr = symaddr + symsize
+            if curr_addr < addr + len(gap_or_val):
+                temp_bytes = bytesToken(gap_or_val[curr_addr - addr :])
+                curr_bytes = add_bytes(curr_bytes, temp_bytes) if curr_bytes else temp_bytes
+            sparse_k = sb_bytes_cons(sb_bytes(curr_bytes), sparse_k)
+        else:
+            raise AssertionError()
+    return sparse_k
+
+
+def _init_config(
+    symbolic_bytes: dict[int, tuple[int, str]], build_config: BuildConfig, elf_file: Path, kriscv: Tools
+) -> CTerm:
+    sparse_bytes = sparse_symbolic_bytes(_memory_segments(elf_file), symbolic_bytes)
+    (end_symbol,) = get_symbols(elf_file, build_config.end_pattern)
+    with _elf_file(elf_file) as elf:
+        end_addr = read_unique_symbol(elf, end_symbol, error_loc=str(elf_file))
+        halt_cond = halt_at_address(word(end_addr))
+    config_vars = {
+        '$REGS': regs(dict.fromkeys(range(32), 0)),
+        '$MEM': sparse_bytes,
+        '$PC': entry_point(elf_file),
+        '$HALT': halt_cond,
+    }
+
+    constraints = [mlEqualsTrue(eqInt(length_bytes(var), intToken(size))) for size, var in symbolic_bytes.items()]
+    return CTerm(kriscv.init_config(config_vars), constraints)
+
+
+def _final_config(symtools: SymTools) -> CTerm:
+    config = CTerm(symtools.kprove.definition.empty_config(KSort('GeneratedTopCell')))
+    _final_subst = {vname: KVariable('FINAL_' + vname) for vname in config.free_vars}
+    _final_subst['INSTRS_CELL'] = KSequence([KApply('#HALT_RISCV-TERMINATION_KItem'), KVariable('FINAL_INSTRS_CELL')])
+    final_subst = CSubst(Subst(_final_subst))
+    return final_subst(config)
+
+
+@pytest.mark.parametrize(
+    'test_id,arg_count,build_config',
+    PROVE_TEST_DATA,
+    ids=[test_id for test_id, *_ in PROVE_TEST_DATA],
+)
+def test_add(
+    symtools: SymTools,
+    tools: Callable[[str], Tools],
+    load_template: TemplateLoader,
+    test_id: str,
+    arg_count: int,
+    build_config: BuildConfig,
+) -> None:
+    # Given
+    elf_file = build_elf(test_id, load_template, build_config)
+    args = {resolve_symbol(elf_file, f'OP{i}'): (32, f'W{i}') for i in range(0, arg_count)}
+
+    init_config = _init_config(args, build_config, elf_file, tools(build_config.target))
+    kclaim = cterm_build_claim(test_id.upper(), init_config, _final_config(symtools))
+    proof = APRProof.from_claim(symtools.kprove.definition, kclaim[0], {}, symtools.proof_dir)
+
+    # When
+    with symtools.explore(id='ADD') as kcfg_explore:
+        prover = APRProver(
+            kcfg_explore=kcfg_explore,
+            execute_depth=1,
+        )
+        prover.advance_proof(proof, max_iterations=45)
+        proof_show = APRProofShow(symtools.kprove)
+        with open(DEBUG_DIR / 'proof-result.txt', 'w') as f:
+            f.write('\n'.join(proof_show.show(proof, [node.id for node in proof.kcfg.nodes])))
+
+    # Then ???

--- a/src/tests/integration/test_prove.py
+++ b/src/tests/integration/test_prove.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Callable, Final, cast
+from typing import TYPE_CHECKING, Final, cast
+from collections.abc import Callable
 
 import pytest
 from kriscv.elf_parser import _memory_segments, entry_point, read_unique_symbol

--- a/src/tests/integration/utils.py
+++ b/src/tests/integration/utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
+from collections.abc import Iterator
 
 from pyk.utils import run_process_2
 

--- a/src/tests/integration/utils.py
+++ b/src/tests/integration/utils.py
@@ -1,14 +1,137 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterator, NamedTuple
 
 if TYPE_CHECKING:
     from typing import Final
 
+    from elftools.elf.elffile import ELFFile  # type: ignore
+
 
 TEST_DATA_DIR: Final = (Path(__file__).parent / 'test-data').resolve(strict=True)
 DEPS_DIR: Final = (Path(__file__).parents[3] / 'deps').resolve(strict=True)
+TEMPLATE_DIR: Final = TEST_DATA_DIR / 'templates'
 
 RISC0_VERSION: Final = (DEPS_DIR / 'risc0_release').read_text().rstrip()
 SP1_VERSION: Final = (DEPS_DIR / 'sp1_release').read_text().rstrip()
+
+
+class TemplateLoader:
+    """
+    A class for loading templates and rendering them with context.
+
+    Attributes:
+        _path: The path to the directory containing the templates.
+    """
+
+    _path: Path
+
+    def __init__(self, path: Path):
+        self._path = path
+
+    def __call__(
+        self,
+        *,
+        template_name: str,
+        context: dict[str, str],
+    ) -> Path:
+        from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+        src_dir = TEMPLATE_DIR / template_name
+        trg_dir = self._path / template_name
+
+        template_files = [path.relative_to(src_dir) for path in src_dir.rglob('*') if path.is_file()]
+        env = Environment(loader=FileSystemLoader(str(src_dir)), undefined=StrictUndefined)
+        for file in template_files:
+            template = env.get_template(str(file))
+            rendered = template.render(context)
+            out_file = trg_dir / file
+            out_file.parent.mkdir(parents=True, exist_ok=True)
+            out_file.write_text(rendered)
+
+        return trg_dir
+
+
+class BuildConfig(NamedTuple):
+    build_cmd: tuple[str, ...]
+    zkvm_deps: str
+    src_header: str
+    elf_path: str
+    end_pattern: str
+    target: str
+
+
+def dedent(text: str) -> str:
+    import textwrap
+
+    return textwrap.dedent(text).strip()
+
+
+RISC0_CONFIG: Final = BuildConfig(
+    build_cmd=('cargo', 'risczero', 'build'),
+    zkvm_deps=dedent(
+        f"""
+        bytemuck_derive = "=1.8.1"
+        risc0-zkvm = {{ version = "={RISC0_VERSION}", default-features = false }}
+        """
+    ),
+    src_header=dedent(
+        """
+        #![no_main]
+        #![no_std]
+        #![feature(unsafe_attributes)]
+        risc0_zkvm::guest::entry!(main);
+        """
+    ),
+    elf_path='target/riscv32im-risc0-zkvm-elf/docker',
+    end_pattern='sys_halt',
+    target='zkevm-semantics.risc0',
+)
+
+SP1_CONFIG: Final = BuildConfig(
+    build_cmd=('cargo', 'prove', 'build'),
+    zkvm_deps=f'sp1-zkvm = "={SP1_VERSION}"',
+    src_header=dedent(
+        """
+        #![no_main]
+        sp1_zkvm::entrypoint!(main);
+        """
+    ),
+    elf_path='target/elf-compilation/riscv32im-succinct-zkvm-elf/release',
+    end_pattern='_ZN8sp1_zkvm8syscalls4halt12syscall_halt*',
+    target='zkevm-semantics.sp1',
+)
+
+
+def resolve_symbol(elf_file: Path, symbol: str) -> int:
+    from kriscv.elf_parser import read_unique_symbol
+
+    with _elf_file(file=elf_file) as elf:
+        return read_unique_symbol(elf, symbol, error_loc=None)
+
+
+def get_symbols(elf_file: Path, pattern: str) -> list[str]:
+    import fnmatch
+
+    with _elf_file(file=elf_file) as elf:
+        symtab = elf.get_section_by_name('.symtab')
+        assert symtab
+
+        func_symbols = [
+            sym.name
+            for sym in symtab.iter_symbols()
+            if sym['st_info']['type'] == 'STT_FUNC'  # Check if symbol type is FUNC
+        ]
+
+        return fnmatch.filter(func_symbols, pattern)
+
+
+@contextmanager
+def _elf_file(file: Path) -> Iterator[ELFFile]:
+    from elftools.elf.elffile import ELFFile  # type: ignore
+
+    with file.open('rb') as f:
+        elf = ELFFile(f)
+        yield elf


### PR DESCRIPTION
- consolidate auxilary functions.
- make the input arguments for the `ADD` opcode symbolic and execute a proof.